### PR TITLE
Add Job Info Component and Service

### DIFF
--- a/src/app/components/job-info/job-info.component.html
+++ b/src/app/components/job-info/job-info.component.html
@@ -1,0 +1,10 @@
+<!-- <p>job-info works!</p> -->
+
+<div *ngIf="jobInfo">
+  <p>Jobs Count:
+    {{ jobInfo.jobPostingsCount }}
+  </p>
+  <p>Cut Off Date:
+    {{ jobInfo.cutOffDate | date }}
+  </p>
+</div>

--- a/src/app/components/job-info/job-info.component.spec.ts
+++ b/src/app/components/job-info/job-info.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { JobInfoComponent } from './job-info.component';
+
+describe('JobInfoComponent', () => {
+  let component: JobInfoComponent;
+  let fixture: ComponentFixture<JobInfoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [JobInfoComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(JobInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/job-info/job-info.component.ts
+++ b/src/app/components/job-info/job-info.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input, OnChanges, SimpleChange } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { JobInfoService } from '../../services/job-info-service/job-info.service';
+
+@Component({
+  selector: 'app-job-info',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './job-info.component.html',
+  styleUrl: './job-info.component.css',
+})
+export class JobInfoComponent implements OnChanges {
+  @Input() selectedRoleId: number | null = null;
+  public jobInfo: any;
+
+  constructor(private jobInfoService: JobInfoService) {}
+
+  ngOnChanges(): void {
+    if (this.selectedRoleId) {
+      this.jobInfoService.getJobInfo(this.selectedRoleId).subscribe(
+        (data) => {
+          this.jobInfo = data;
+        },
+        (error) => {
+          console.error('Error fetching job info:', error);
+        }
+      );
+    }
+  }
+}

--- a/src/app/components/role-selection/role-selection.component.ts
+++ b/src/app/components/role-selection/role-selection.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RolesService } from '../../services/roles.service';
+import { RolesService } from '../../services/job-roles-service/job-roles.service';
 
 @Component({
   selector: 'app-role-selection',

--- a/src/app/components/trending-skills-visualisation/trending-skills-visualisation.component.ts
+++ b/src/app/components/trending-skills-visualisation/trending-skills-visualisation.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { ChartDataset, ChartOptions, ChartType } from 'chart.js';
 import { NgChartsModule } from 'ng2-charts';
-import { SkillsService } from '../../services/skills.service';
+import { SkillsService } from '../../services/role-skills-service/role-skills.service';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -15,7 +15,7 @@ export class TrendingSkillsVisualisationComponent implements OnChanges {
   @Input() selectedRoleId: number | null = null;
   @Input() category: string | null = null;
   public barChartData: ChartDataset[] = [{ data: [], label: '' }];
-  public barChartLabels: string[] = []; // Changed to string array
+  public barChartLabels: string[] = [];
   public barChartOptions: ChartOptions = {
     responsive: true,
     indexAxis: 'y',
@@ -39,27 +39,22 @@ export class TrendingSkillsVisualisationComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.category && this.selectedRoleId) {
-      this.SkillsService.getSkillsForRole(this.selectedRoleId).subscribe(
-        (data) => {
-          this.processData(data);
+      this.SkillsService.getSkillsForRole(
+        this.selectedRoleId,
+        this.category
+      ).subscribe(
+        (responses) => {
+          this.barChartLabels = responses.map(
+            (response) => response.skill.skillName
+          );
+          this.barChartData[0].data = responses.map(
+            (response) => response.frequency
+          );
         },
         (error) => {
           console.error('Error retrieving skills data:', error);
         }
       );
     }
-  }
-
-  private processData(data: any[]): void {
-    let filteredData = data.filter(
-      (d) =>
-        d.skill.type.typeName.toUpperCase() === this.category?.toUpperCase()
-    );
-
-    filteredData = filteredData
-      .sort((a, b) => b.frequency - a.frequency)
-      .slice(0, 20);
-    this.barChartLabels = filteredData.map((d) => d.skill.skillName);
-    this.barChartData[0].data = filteredData.map((d) => d.frequency);
   }
 }

--- a/src/app/pages/homepage/homepage.component.html
+++ b/src/app/pages/homepage/homepage.component.html
@@ -1,5 +1,7 @@
 <app-role-selection (roleSelected)="selectedRoleId = $event"></app-role-selection>
 
+<app-job-info [selectedRoleId]="selectedRoleId"></app-job-info>
+
 <div *ngIf="selectedRoleId" class="visualisation">
   <app-trending-skills-visualisation [selectedRoleId]="selectedRoleId" [category]="'Language'">
   </app-trending-skills-visualisation>

--- a/src/app/pages/homepage/homepage.component.ts
+++ b/src/app/pages/homepage/homepage.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RoleSelectionComponent } from '../../components/role-selection/role-selection.component';
 import { TrendingSkillsVisualisationComponent } from '../../components/trending-skills-visualisation/trending-skills-visualisation.component';
+import { JobInfoComponent } from '../../components/job-info/job-info.component';
 
 @Component({
   selector: 'app-homepage',
@@ -10,6 +11,7 @@ import { TrendingSkillsVisualisationComponent } from '../../components/trending-
     CommonModule,
     RoleSelectionComponent,
     TrendingSkillsVisualisationComponent,
+    JobInfoComponent,
   ],
   templateUrl: './homepage.component.html',
   styleUrl: './homepage.component.css',

--- a/src/app/services/job-info-service/job-info.service.spec.ts
+++ b/src/app/services/job-info-service/job-info.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { JobInfoService } from './job-info.service';
+
+describe('JobInfoService', () => {
+  let service: JobInfoService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(JobInfoService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/job-info-service/job-info.service.ts
+++ b/src/app/services/job-info-service/job-info.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class JobInfoService {
+  private apiUrl = `${environment.apiUrl}/api/roles`;
+
+  constructor(private http: HttpClient) {}
+
+  getJobInfo(
+    roleId: number
+  ): Observable<{ jobCount: number; cutOffDate: Date }> {
+    const url = `${this.apiUrl}/${roleId}/jobInfo`;
+    return this.http.get<{ jobCount: number; cutOffDate: Date }>(url);
+  }
+}

--- a/src/app/services/job-roles-service/job-roles.service.spec.ts
+++ b/src/app/services/job-roles-service/job-roles.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { RolesService } from './roles.service';
+import { RolesService } from './job-roles.service';
 
 describe('RolesService', () => {
   let service: RolesService;

--- a/src/app/services/job-roles-service/job-roles.service.ts
+++ b/src/app/services/job-roles-service/job-roles.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/services/role-skills-service/role-skills.service.spec.ts
+++ b/src/app/services/role-skills-service/role-skills.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { SkillsService } from './skills.service';
+import { SkillsService } from './role-skills.service';
 
 describe('SkillsService', () => {
   let service: SkillsService;

--- a/src/app/services/role-skills-service/role-skills.service.ts
+++ b/src/app/services/role-skills-service/role-skills.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -11,8 +11,8 @@ export class SkillsService {
 
   constructor(private http: HttpClient) {}
 
-  getSkillsForRole(roleId: number): Observable<any[]> {
-    const url = `${this.apiUrl}/${roleId}/skills`;
+  getSkillsForRole(roleId: number, category: string | null): Observable<any[]> {
+    const url = `${this.apiUrl}/${roleId}/skills/${category}`;
     return this.http.get<any[]>(url);
   }
 }


### PR DESCRIPTION
- Created a new component named 'job-info' to visualize the number of jobs for which skills are displayed, providing context to the visualisations.
- Added a corresponding service for 'job-info' to handle data retrieval and filtering from the API.
- Removed the 'processData' function from 'trending-skills-visualisations component as data is preprocessed and filtered in the backend.